### PR TITLE
Support for package comments in GtDocumenter

### DIFF
--- a/src/GToolkit-Documenter/GtDocumenter.class.st
+++ b/src/GToolkit-Documenter/GtDocumenter.class.st
@@ -31,6 +31,11 @@ GtDocumenter class >> forFile: aFileReference [
 ]
 
 { #category : #'instance creation' }
+GtDocumenter class >> forPackage: anRPackage [
+	^ self new packageComment: anRPackage; read
+]
+
+{ #category : #'instance creation' }
 GtDocumenter class >> forText: aStringOrText [
 	^ self new text: aStringOrText
 ]
@@ -406,6 +411,12 @@ GtDocumenter >> normalFontSize [
 { #category : #'api - styling' }
 GtDocumenter >> normalFontSize: aNumber [
 	self editorElement normalFontSize: aNumber.
+]
+
+{ #category : #'api - storage' }
+GtDocumenter >> packageComment: anRPackage [
+	self editorElement packageComment: anRPackage.
+	self updateTitleLabel.
 ]
 
 { #category : #'api - ast' }

--- a/src/GToolkit-Documenter/GtDocumenterEditor.class.st
+++ b/src/GToolkit-Documenter/GtDocumenterEditor.class.st
@@ -134,6 +134,11 @@ GtDocumenterEditor >> normalFontSize: aNumber [
 ]
 
 { #category : #'api - storage' }
+GtDocumenterEditor >> packageComment: anRPackage [
+	storageModel packageComment: anRPackage
+]
+
+{ #category : #'api - storage' }
 GtDocumenterEditor >> read [
 	^ storageModel read
 ]

--- a/src/GToolkit-Documenter/GtDocumenterEditorStorageModel.class.st
+++ b/src/GToolkit-Documenter/GtDocumenterEditorStorageModel.class.st
@@ -80,6 +80,14 @@ GtDocumenterEditorStorageModel >> notifyStorageChanged [
 ]
 
 { #category : #'api - storage' }
+GtDocumenterEditorStorageModel >> packageComment: anRPackage [ 
+	self 
+		assert: [ anRPackage notNil ]
+		description: [ 'Package to document must be non-nil' ].
+	self storage: (GtStorageStrategy packageComment: anRPackage)
+]
+
+{ #category : #'api - storage' }
 GtDocumenterEditorStorageModel >> read [
 	self widgetDo: [ :aDocumenter |
 		self storage read: aDocumenter ]

--- a/src/GToolkit-Documenter/GtPackageCommentStrategy.class.st
+++ b/src/GToolkit-Documenter/GtPackageCommentStrategy.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : #GtPackageCommentStrategy,
+	#superclass : #GtStorageStrategy,
+	#instVars : [
+		'package'
+	],
+	#category : #'GToolkit-Documenter-Storage'
+}
+
+{ #category : #accessing }
+GtPackageCommentStrategy >> basename [
+	"Return a string representing the document filename"
+	<return: #String>
+	^ self name, '.', GtFileUtilityConstants pillarExtension
+]
+
+{ #category : #accessing }
+GtPackageCommentStrategy >> comment [
+	<return: #String>
+	^ self packageToComment packageManifestOrNil
+		ifNil: [ '' ]
+		ifNotNil: [ :manifest |
+			manifest hasComment 
+				ifTrue: [ manifest comment ] 
+				ifFalse: [ '' ] ]
+]
+
+{ #category : #accessing }
+GtPackageCommentStrategy >> evaluationReceiver [
+	"Return an object that is used as a receiver (self) in a codeblock (code snippet) evalution"
+	<return: #Object>
+	^ self packageToComment
+]
+
+{ #category : #testing }
+GtPackageCommentStrategy >> exists [
+	<return: #Boolean>
+	^ true
+]
+
+{ #category : #accessing }
+GtPackageCommentStrategy >> name [
+	"Return a string representing the stored document"
+	<return: #String>
+	^ self packageToComment name
+]
+
+{ #category : #accessing }
+GtPackageCommentStrategy >> packageToComment [
+	^ package
+]
+
+{ #category : #accessing }
+GtPackageCommentStrategy >> packageToComment: anRPackage [
+	self 
+		assert: [ anRPackage notNil ]
+		description: [ 'Package to document must be non-nil' ].
+	package := anRPackage
+]
+
+{ #category : #actions }
+GtPackageCommentStrategy >> read: aGt2Document [
+	aGt2Document text: self comment
+]
+
+{ #category : #accessing }
+GtPackageCommentStrategy >> rootDirectory [
+	<return: #FileReference>
+	^ FileSystem workingDirectory
+]
+
+{ #category : #actions }
+GtPackageCommentStrategy >> save: aGt2Document [ 
+	self packageToComment packageManifest
+		comment: aGt2Document text asString
+			stamp: Author changeStamp
+]

--- a/src/GToolkit-Documenter/GtStorageStrategy.class.st
+++ b/src/GToolkit-Documenter/GtStorageStrategy.class.st
@@ -31,6 +31,16 @@ GtStorageStrategy class >> null [
 	^ GtNoStorageStrategy uniqueInstance
 ]
 
+{ #category : #factory }
+GtStorageStrategy class >> packageComment [
+	^ GtPackageCommentStrategy new
+]
+
+{ #category : #factory }
+GtStorageStrategy class >> packageComment: anRPackage [
+	^ self packageComment packageToComment: anRPackage
+]
+
 { #category : #accessing }
 GtStorageStrategy >> basename [
 	"Return a string representing the document filename"


### PR DESCRIPTION
Adds class `GtPackageCommentStrategy` for managing package comments, plus all the required plumbing up to the new class method `forPackage:` on `GtDocumenter`.